### PR TITLE
Refactor styles image header

### DIFF
--- a/src/characters/components/CharactersList/CharactersList.scss
+++ b/src/characters/components/CharactersList/CharactersList.scss
@@ -1,6 +1,8 @@
 .characters {
   display: grid;
   justify-items: center;
+  align-items: stretch;
+  gap: 10px;
 
   @media (width < 420px) {
     grid-template-columns: 1fr;

--- a/src/components/App/App.scss
+++ b/src/components/App/App.scss
@@ -1,7 +1,7 @@
 .main-container {
   padding: 10px;
   margin: 0 auto;
-  max-width: 700px;
+  max-width: 500px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -20,4 +20,10 @@
     padding: 0;
     gap: 8px;
   }
+}
+
+.header__image {
+  height: 78px;
+  object-fit: cover;
+  width: 100%;
 }

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -1,16 +1,25 @@
 import { Outlet } from "react-router-dom";
-import "./App.scss";
 import Header from "../Header/Header";
 import NavigationMenu from "../NavigationMenu/NavigationMenu";
+import "./App.scss";
 
 const App = () => {
   return (
-    <div className="main-container">
-      <Header />
-      <NavigationMenu />
-      <main className="main-content">
-        <Outlet />
-      </main>
+    <div>
+      <img
+        className="header__image"
+        src="https://distritooficina.com/wp-content/uploads/2023/08/image-1080x757.jpg"
+        alt="Imagen de la oficina de The Office"
+        width="415"
+        height="78"
+      />
+      <div className="main-container">
+        <Header />
+        <NavigationMenu />
+        <main className="main-content">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 };

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,9 +1,3 @@
 .main-header {
   width: 100%;
-
-  &__image {
-    width: 100vw;
-    height: 78px;
-    object-fit: cover;
-  }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,15 +3,6 @@ import "./Header.scss";
 const Header = (): React.ReactElement => {
   return (
     <header className="main-header">
-      <div>
-        <img
-          className="main-header__image"
-          src="https://distritooficina.com/wp-content/uploads/2023/08/image-1080x757.jpg"
-          alt="Imagen de la oficina de The Office"
-          width="415"
-          height="78"
-        />
-      </div>
       <h1 className="main-title">The Office App</h1>
     </header>
   );

--- a/src/components/NavigationMenu/NavigationMenu.scss
+++ b/src/components/NavigationMenu/NavigationMenu.scss
@@ -2,6 +2,11 @@
   display: flex;
   align-self: self-start;
   color: #142f38;
+
+  &__links {
+    display: flex;
+    gap: 10px;
+  }
 }
 
 .active {

--- a/src/components/NavigationMenu/NavigationMenu.tsx
+++ b/src/components/NavigationMenu/NavigationMenu.tsx
@@ -4,7 +4,7 @@ import "./NavigationMenu.scss";
 const NavigationMenu = (): React.ReactElement => {
   return (
     <nav className="navigation-menu">
-      <ul>
+      <ul className="navigation-menu__links">
         <li>
           <NavLink className={"link"} to="/characters">
             Home

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -12,9 +12,6 @@ body {
 
 ul,
 li {
-  display: flex;
-  align-items: stretch;
-  gap: 10px;
   list-style: none;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
He separado la imagen del header del main container, para poderle dar a esta el máximo del tamaño del contenedor y centrar todo aquello que exista en el main-container sin perjudicar a la primera. 